### PR TITLE
iOS support

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -38,5 +38,15 @@
 
         <source-file src="src/android/AboutScreen.java" target-dir="src/com/github/josephma93/aboutscreen" />
     </platform>
-
+	
+	<platform name="ios">
+		<config-file target="config.xml" parent="/*">
+			<feature name="AboutScreen">
+				<paran name="ios-package" value="AboutScreen" />
+			</feature>
+		</config-file>
+		
+		<header-file src="src/ios/AboutScreen.h" />
+		<source-file src="src/ios/AboutScreen.m" />
+	</platform>
 </plugin>

--- a/plugin.xml
+++ b/plugin.xml
@@ -38,15 +38,15 @@
 
         <source-file src="src/android/AboutScreen.java" target-dir="src/com/github/josephma93/aboutscreen" />
     </platform>
-	
-	<platform name="ios">
-		<config-file target="config.xml" parent="/*">
-			<feature name="AboutScreen">
-				<paran name="ios-package" value="AboutScreen" />
-			</feature>
-		</config-file>
-		
-		<header-file src="src/ios/AboutScreen.h" />
-		<source-file src="src/ios/AboutScreen.m" />
-	</platform>
+   
+   <platform name="ios">
+      <config-file target="config.xml" parent="/*">
+         <feature name="AboutScreen">
+            <param name="ios-package" value="AboutScreen" />
+         </feature>
+      </config-file>
+      
+      <header-file src="src/ios/AboutScreen.h" />
+      <source-file src="src/ios/AboutScreen.m" />
+   </platform>
 </plugin>

--- a/src/ios/AboutScreen.h
+++ b/src/ios/AboutScreen.h
@@ -1,0 +1,7 @@
+#import <Cordova/CDV.h>
+
+@interface AboutScreen : CDVPlugin
+
+- (void)getInfo:(CDVInvokedUrlCommand*)command;
+
+@end

--- a/src/ios/AboutScreen.m
+++ b/src/ios/AboutScreen.m
@@ -5,7 +5,42 @@
 
 - (void)getInfo:(CDVInvokedUrlCommand*)command
 {
-	
+	CDVPluginResult* pluginResult = nil;
+    
+    // For reference, look at http://stackoverflow.com/questions/4779221/in-iphone-app-how-to-detect-the-screen-resolution-of-the-device
+    
+    // This returns the screen size in "points". ie 320x480 in iPhones
+    CGRect screenBounds = [[UIScreen mainScreen] bounds];
+    
+    // To get the actual pixels, we need to multiply by the screen scale.
+    float screenScale = 1;
+    if ([[UIScreen mainScreen] respondsToSelector:@selector(scale)]) {
+        screenScale = [[UIScreen mainScreen] scale];
+    }
+    
+    CGFloat screenWidth = screenBounds.size.width * screenScale;
+    CGFloat screenHeight = screenBounds.size.height * screenScale;
+    
+    // http://stackoverflow.com/questions/3860305/get-ppi-of-iphone-ipad-ipod-touch-at-runtime
+    float dpi;
+    if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad) {
+        dpi = 132 * screenScale;
+    } else if (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPhone) {
+        dpi = 163 * screenScale;
+    } else {
+        dpi = 160 * screenScale;
+    }
+    
+    float diagonal = sqrtf(screenWidth*screenWidth + screenHeight*screenHeight) / dpi;
+    
+    NSDictionary *info = @{ @"width" : [NSNumber numberWithFloat:screenWidth],
+                            @"height" : [NSNumber numberWithFloat:screenHeight],
+                            @"density" : [NSNumber numberWithFloat:dpi],
+                            @"screenDiagonal" : [NSNumber numberWithFloat:diagonal]
+                            };
+    
+    pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsDictionary:info];
+    [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
 }
 
 @end

--- a/src/ios/AboutScreen.m
+++ b/src/ios/AboutScreen.m
@@ -1,0 +1,11 @@
+#import "AboutScreen.h"
+#import <Cordova/CDV.h>
+
+@implementation AboutScreen
+
+- (void)getInfo:(CDVInvokedUrlCommand*)command
+{
+	
+}
+
+@end


### PR DESCRIPTION
I just added iOS support for this plugin. (Why use cross-platform if you use platform-specific plugins? :P)

Just note: The dpi is wrong in iPhone 6 plus, because `[[UIScreen mainScreen] scale]` returns `3.0f` when in fact the iPhone 6 plus has a scale of `2.46f` (source: http://dpi.lv/#1080×1980@5.5″)
I really can't do `if (scale == 3.0f) scale = 2.46f` because who knows if later they take out a `3.0f`-real device
